### PR TITLE
Fix server serving files with wrong mime-type

### DIFF
--- a/server/src/http_server.rs
+++ b/server/src/http_server.rs
@@ -239,7 +239,7 @@ impl HttpServer {
     fn extract_file_extension(path: &str) -> FileExtension {
         let extension: Vec<&str> = path.split(".").collect();
         debug!("Extracting extension: {:#?}", extension);
-        match extension[1] {
+        match extension[extension.len()-1] {
             "css" => {
                 FileExtension::CSS
             },


### PR DESCRIPTION
Make sure mimetype corresponds to proper extension as indicated by what comes after the last instead of the first dot in filename.